### PR TITLE
Custom inspect methods for Trip and TripDispatcher

### DIFF
--- a/lib/trip.rb
+++ b/lib/trip.rb
@@ -17,5 +17,12 @@ module RideShare
         raise ArgumentError.new("Invalid rating #{@rating}")
       end
     end
+
+    def inspect
+      "#<#{self.class.name}:0x#{self.object_id.to_s(16)} " +
+      "ID=#{id.inspect} " +
+      "DriverID=#{driver&.id.inspect} " +
+      "PassengerID=#{passenger&.id.inspect}>"
+    end
   end
 end

--- a/lib/trip_dispatcher.rb
+++ b/lib/trip_dispatcher.rb
@@ -90,6 +90,13 @@ module RideShare
       trips
     end
 
+    def inspect
+      "#<#{self.class.name}:0x#{self.object_id.to_s(16)} " +
+      "#{trips.count} trips, " +
+      "#{drivers.count} drivers, " +
+      "#{passengers.count} passengers>"
+    end
+
     private
 
     def check_id(id)


### PR DESCRIPTION
These are necessary to prevent Ruby from entering an infinite loop when
trying to inspect an instance of these classes (due to the circular
references between `Trip` and `Driver`/`Passenger`).

Technically it's not required to have a custom inspect for
`TripDispatcher`, but the default behavior would result in printing out
every single `Trip`, `Driver`, and `Passenger` in its instance variables which
is a huuuuge block of text that is entirely unhelpful.

Instead, we list the counts of each of those arrays.