### PR TITLE
Readme time link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## At a Glance
 
 - Pair, [stage 2](https://github.com/Ada-Developers-Academy/pedagogy/blob/master/rule-of-three.md#stage-2) project
-- Due End Of Day Friday, August 30th
+- Due before class, *DATE HERE*
 
 ## Introduction
 
@@ -144,7 +144,7 @@ The purpose of Wave 1 is to help you become familiar with the existing code, and
 
 #### 1.1: Upgrading Times
 
-Currently our implementation saves the start and end time of each trip as a string. This is our first target for improvement. Instead of storing these values as strings, we will use [Ruby's built-in `Time` class](https://ruby-doc.org/core-2.5.1/Time.html). You should:
+Currently our implementation saves the start and end time of each trip as a string. This is our first target for improvement. Instead of storing these values as strings, we will use [Ruby's built-in `Time` class](https://ruby-doc.org/stdlib-2.5.5/libdoc/time/rdoc/Time.html). You should:
 
 1.  Spend some time reading the docs for `Time` - you might be particularly interested in `Time.parse`
 1.  Modify `Trip.from_csv` to turn `start_time` and `end_time` into `Time` instances before passing them to `Trip#initialize`


### PR DESCRIPTION
README says look for "parse" method, but Ruby core `Time` docs don't have "parse". But Ruby stdlib `Time` docs do have "parse":
No "parse": https://ruby-doc.org/core-2.5.1/Time.html
"Parse": https://ruby-doc.org/stdlib-2.5.5/libdoc/time/rdoc/Time.html